### PR TITLE
ancestryの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,5 @@ gem 'devise'
 gem 'minitest', '~> 5.25'
 
 gem 'brakeman', '~> 8.0', '>= 8.0.4'
+
+gem 'ancestry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,9 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.9)
       public_suffix (>= 2.0.2, < 8.0)
+    ancestry (5.1.0)
+      activerecord (>= 5.2.6)
+      logger
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt (3.1.21)
@@ -338,6 +341,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  ancestry
   bootsnap
   brakeman (~> 8.0, >= 8.0.4)
   capybara
@@ -372,6 +376,7 @@ CHECKSUMS
   activestorage (7.2.2) sha256=2448162d87a874586515a15caae224b17c4693459e321d68ab54914de94b630e
   activesupport (7.2.2) sha256=436360924cf758dfa9d60ab22a8afe6da8babf6f1286d4087f0a9c576bf8328a
   addressable (2.8.9) sha256=cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485
+  ancestry (5.1.0) sha256=8a073cf6f7e306eeed36af72595abd19602ef4a197bf4beda2f31cf8f55de27b
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bcrypt (3.1.21) sha256=5964613d750a42c7ee5dc61f7b9336fb6caca429ba4ac9f2011609946e4a2dcf


### PR DESCRIPTION
## 概要
メモの親子構造を実装する準備として、gem ancestry を導入しました。
まずは依存関係のみを追加し、今後の Memo モデル実装の土台を整えています。

## 背景
本アプリの新規登録およびログイン後のメモのタイトル一覧をツリー構造で管理するため、親子関係を扱える仕組みが必要でした。
issue #12 

## 変更内容
- Gemfile に gem "ancestry" を追加
- Gemfile.lock を更新
- メモの階層構造実装に向けた依存関係を追加

## 確認方法
- bundle install が成功することを確認
- Gemfile に gem "ancestry" が追加されていることを確認
- Gemfile.lock が更新されていることを確認

## 影響範囲
### 影響がある画面/機能
直接的な画面変更なし  
今後の Memo モデルおよびメモの親子構造実装に影響

### 影響がないこと
現時点では既存画面・既存機能の挙動に変更はありません

### 補足
今回は ancestry の導入のみを対象としています。  
memos テーブル作成、Memo モデルへの has_ancestry 追加、関連付けやテスト整備は後続PRで対応予定です。