### PR TITLE
Memoモデルの作成

### DIFF
--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Memo < ApplicationRecord
+  has_ancestry
+
+  belongs_to :user
+
+  validates :title, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,5 +6,6 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  has_many :memos, dependent: :destroy
   validates :name, presence: true
 end

--- a/db/migrate/20260320013110_create_memos.rb
+++ b/db/migrate/20260320013110_create_memos.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateMemos < ActiveRecord::Migration[7.2]
+  def change
+    create_table :memos do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title, null: false
+      t.text :content
+      t.string :ancestry
+
+      t.timestamps
+    end
+
+    add_index :memos, :ancestry
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,9 +12,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 20_260_318_071_405) do
+ActiveRecord::Schema[7.2].define(version: 20_260_320_013_110) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
+
+  create_table 'memos', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.string 'title', null: false
+    t.text 'content'
+    t.string 'ancestry'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['ancestry'], name: 'index_memos_on_ancestry'
+    t.index ['user_id'], name: 'index_memos_on_user_id'
+  end
 
   create_table 'users', force: :cascade do |t|
     t.string 'name', null: false
@@ -24,4 +35,6 @@ ActiveRecord::Schema[7.2].define(version: 20_260_318_071_405) do
     t.datetime 'updated_at', null: false
     t.index ['email'], name: 'index_users_on_email', unique: true
   end
+
+  add_foreign_key 'memos', 'users'
 end

--- a/test/fixtures/memos.yml
+++ b/test/fixtures/memos.yml
@@ -1,0 +1,11 @@
+one:
+  user: one
+  title: サンプルメモ1
+  content: MyText
+  ancestry: MyString
+
+two:
+  user: two
+  title: サンプルメモ2
+  content: MyText
+  ancestry: MyString

--- a/test/models/memo_test.rb
+++ b/test/models/memo_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MemoTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
Memoモデルとmemosテーブルを作成しました。  
あわせて、Userとの関連付け・Ancestry対応・fixture / model test の土台を追加しました。

## 背景
本アプリでは、ログイン後にユーザーごとにメモを管理し、さらに親子関係を持つツリー構造で扱う必要があります。  
そのため、メモ機能の中心となるMemoモデルとmemosテーブルの実装が必要でした。　　
Issue:  #11 

## 変更内容
- Memo モデルを作成
- memos テーブルを作成
- memos テーブルに以下のカラムを追加
- user_id
- title
- content
- ancestry
- created_at
- updated_at
- user_id に外部キー制約を追加
- title を null: false に設定
- ancestry に index を追加
- Memo モデルに belongs_to :user を追加
- Memo モデルに has_ancestry を追加
- Memo モデルに title のバリデーションを追加
- User モデルに has_many :memos を追加
- memos.yml と memo_test.rb を追加

## 確認方法
- docker compose exec web rails db:migrate を実行
- db/schema.rb に memos テーブルが追加されていることを確認
- Memo モデルに belongs_to :user と has_ancestry があることを確認
- User モデルに has_many :memos が追加されていることを確認
- 以下コマンドが通ることを確認
   - docker compose exec web rails test
   - docker compose exec web bundle exec rubocop
   - docker compose exec web bundle exec brakeman --no-progress --no-pager --no-exit-on-warn

## 影響範囲
### 影響がある画面/機能
- メモ機能の今後の実装全般
- ユーザーとメモの関連付け
- メモの親子構造実装の土台

### 影響がないこと
現時点では画面表示や既存の認証機能には直接影響しません

## 補足
今回はMemoモデルとDB設計の土台作成までを対象としています。  
一覧画面・詳細画面・作成画面などのメモ機能本体は、後続PRで対応予定です。