### PR TITLE
認証導線の整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,4 +666,4 @@ Figma：<https://www.figma.com/design/LjIbl8Pmw11G4e2dHFzCt4/mind_outline%E7%94%
 
 ## 12. ER図
 
-[![Image from Gyazo](https://i.gyazo.com/053bd109268c9747aaaf3ea553c1413b.png)](https://gyazo.com/053bd109268c9747aaaf3ea553c1413b)
+[![Image from Gyazo](https://i.gyazo.com/d62289b2607984c13a28191988d16b0d.png)](https://gyazo.com/d62289b2607984c13a28191988d16b0d)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  def after_sign_in_path_for(_resource)
+    memos_path
+  end
+
+  def after_sign_out_path_for(_resource_or_scope)
+    root_path
+  end
 end

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MemosController < ApplicationController
+  before_action :authenticate_user!
+
+  def index; end
+end

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -1,0 +1,8 @@
+<% if user_signed_in? %>
+  <h2>ホーム</h2>
+  <p><%= current_user.name %>さん</p>
+  <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %>
+<% else %>
+  <%= link_to "ログイン", new_user_session_path %>
+  <%= link_to "新規登録", new_user_registration_path %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get 'homes/index'
   devise_for :users
+
   root 'homes#index'
+
+  resources :memos, only: [:index]
 end

--- a/db/migrate/20260320073136_add_remember_created_at_to_users.rb
+++ b/db/migrate/20260320073136_add_remember_created_at_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRememberCreatedAtToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :remember_created_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 20_260_320_013_110) do
+ActiveRecord::Schema[7.2].define(version: 20_260_320_073_136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
@@ -33,6 +33,7 @@ ActiveRecord::Schema[7.2].define(version: 20_260_320_013_110) do
     t.string 'encrypted_password', default: '', null: false
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
+    t.datetime 'remember_created_at'
     t.index ['email'], name: 'index_users_on_email', unique: true
   end
 


### PR DESCRIPTION
## 概要
認証導線を整備し、ログイン後に仮のホーム画面へ遷移できるようにしました。  
あわせて、ログアウトできるようにするため、 remember me 用カラム追加を行いました。

## 背景
未ログイン時のアクセス制御、ログイン後の遷移、ログアウト処理を整理し、認証まわりの基本導線を安定させる必要がありました。
Issue:  #40 

## 変更内容
- ApplicationController にログイン後 / ログアウト後の遷移先を設定
- ログイン後に /memos へ遷移するように変更
- ログアウト後にトップページへ戻るように変更
- routes.rb に memos#index を追加
- MemosController を作成
- app/views/memos/index.html.erb を追加し、ログイン後の遷移先となる画面を作成
- remember me に対応するため remember_created_at カラムを users テーブルに追加
- db/schema.rb を更新
- README の ER図を差し替え

## 確認方法
- docker compose up を実行
- http://localhost:3000/ にアクセス
- 未ログイン状態で /memos にアクセスすると、ログイン画面へ遷移することを確認
- ログイン後に /memos へ遷移することを確認
- ログアウトリンク押下後にトップページへ戻ることを確認
- 以下コマンドが通ることを確認
   - docker compose exec web rails test
   - docker compose exec web bundle exec rubocop
   - docker compose exec web bundle exec brakeman --no-progress --no-pager --no-exit-on-warn

## 影響範囲
### 影響がある画面/機能
- ログイン後 / ログアウト後の遷移
- /memos へのアクセス制御
- remember me を含む認証導線

### 影響がないこと
メモ機能本体のCRUDは未実装です。

## スクリーンショット
ログイン後  
[![Image from Gyazo](https://i.gyazo.com/a7741b863c2991a37ee15dd6b23d405d.png)](https://gyazo.com/a7741b863c2991a37ee15dd6b23d405d)

ログアウト後  
[![Image from Gyazo](https://i.gyazo.com/6a621d552cb063e4d90df24e8d11554a.png)](https://gyazo.com/6a621d552cb063e4d90df24e8d11554a)

## 補足
今回は認証導線の整備を対象としております。  
仮のホーム画面を設置し、メモ機能本体の実装は後続のプルリクエストで対応予定です。