### PR TITLE
本番環境の新規登録不具合の修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,20 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
   def after_sign_in_path_for(_resource)
     memos_path
   end
 
   def after_sign_out_path_for(_resource_or_scope)
     root_path
+  end
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
 end


### PR DESCRIPTION
## 概要
Deviseの新規登録時に name を保存できるよう修正しました。  
本番環境で新規登録が失敗していた問題に対応しています。

## 背景
新規登録画面に name 項目を追加していましたが、Devise 側で許可パラメータに name を追加していなかったため、本番環境で登録時に失敗していました。
Issue:  #40 

## 変更内容
- ApplicationController に configure_permitted_parameters を追加
- Devise の sign_up で name を許可
- Devise の account_update で name を許可

## 確認方法
- docker compose up を実行
- http://localhost:3000/users/sign_up にアクセス
- 名前、メールアドレス、パスワード、確認用パスワードを入力して新規登録できることを確認
- 以下コマンドが通ることを確認
   - docker compose exec web rails test
   - docker compose exec web bundle exec rubocop
   - docker compose exec web bundle exec brakeman --no-progress --no-pager --no-exit-on-warn

## 影響範囲
### 影響がある画面/機能
- 新規登録機能
- ユーザー情報更新時の name パラメータ処理

### 影響がないこと
ログイン処理やメモ機能には直接影響ありません

## 補足
本番環境で新規登録できない不具合に対する最小修正です。