### PR TITLE
メモ編集機能の追加

### DIFF
--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -2,7 +2,7 @@
 
 class MemosController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_memo, only: %i[show]
+  before_action :set_memo, only: %i[show edit update destroy]
 
   def index
     @memos = current_user.memos.includes(:user).order(created_at: :desc)
@@ -23,6 +23,21 @@ class MemosController < ApplicationController
   end
 
   def show; end
+
+  def edit; end
+
+  def update
+    if @memo.update(memo_params)
+      redirect_to memo_path(@memo), notice: 'メモを更新しました。'
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @memo.destroy
+    redirect_to memos_path, notice: 'メモを削除しました。'
+  end
 
   private
 

--- a/app/views/memos/edit.html.erb
+++ b/app/views/memos/edit.html.erb
@@ -1,0 +1,33 @@
+<div class="mx-auto max-w-3xl px-4 py-8">
+  <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+    <h2 class="mb-6 text-2xl font-bold text-gray-800">メモ編集</h2>
+
+    <% if @memo.errors.any? %>
+      <div class="mb-4 rounded-lg bg-red-50 p-4 text-red-700">
+        <p class="font-semibold"><%= pluralize(@memo.errors.count, "error") %> <%= @memo.errors.count %>件のエラーがあります。</p>
+        <ul class="mt-2 list-disc pl-5">
+          <% @memo.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <%= form_with model: @memo, local: true do |f| %>
+      <div class="mb-4">
+        <%= f.label :title, "タイトル", class: "mb-2 block text-sm font-semibold text-gray-700" %>
+        <%= f.text_field :title, class: "w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none" %>
+      </div>
+
+      <div class="mb-6">
+        <%= f.label :content, "内容", class: "mb-2 block text-sm font-semibold text-gray-700" %>
+        <%= f.text_area :content, rows: 8, class: "w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none" %>
+      </div>
+
+      <div class="flex gap-3">
+        <%= f.submit "更新する", class: "rounded-lg bg-blue-600 px-4 py-2 font-semibold text-white hover:bg-blue-700" %>
+        <%= link_to "戻る", memo_path(@memo), class: "rounded-lg border border-gray-300 px-4 py-2 font-semibold text-gray-700 hover:bg-gray-50" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -14,8 +14,8 @@
       <p>更新日時: <%= l @memo.updated_at, format: :short %></p>
     </div>
 
-    <div class="border-t border-gray-200 pt-4">
-      <%= link_to "編集", "#", class: "inline-block rounded-lg bg-yellow-500 px-4 py-2 font-semibold text-white hover:bg-yellow-600" %>
+    <div class="mt-4 flex gap-3 border-t border-gray-200 pt-4">
+      <%= link_to "編集", edit_memo_path(@memo), class: "inline-block rounded-lg bg-yellow-500 px-4 py-2 font-semibold text-white hover:bg-yellow-600" %>
       <%= link_to "一覧へ戻る", memos_path, class: "inline-block rounded-lg bg-blue-600 px-4 py-2 font-semibold text-white hover:bg-blue-700" %>
     </div>
   </div>

--- a/test/controllers/memos_controller_test.rb
+++ b/test/controllers/memos_controller_test.rb
@@ -7,7 +7,6 @@ class MemosControllerTest < ActionDispatch::IntegrationTest
 
   setup do
     @user = users(:one)
-    @other_user = users(:two)
     @memo = memos(:one)
     @other_memo = memos(:two)
   end
@@ -93,6 +92,7 @@ class MemosControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "a[href='#{memo_path(@memo)}']", text: '詳細'
   end
+
   test '未ログイン時はメモ詳細画面にアクセスできずログイン画面へリダイレクトされる' do
     get memo_url(@memo)
     assert_redirected_to new_user_session_url

--- a/test/controllers/memos_edit_update_test.rb
+++ b/test/controllers/memos_edit_update_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MemosEditUpdateTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = users(:one)
+    @memo = memos(:one)
+    @other_memo = memos(:two)
+  end
+
+  test '自分のメモ編集画面を表示できる' do
+    sign_in @user
+
+    get edit_memo_url(@memo)
+    assert_response :success
+    assert_select 'h2', text: 'メモ編集'
+    assert_match @memo.title, response.body
+    assert_match @memo.content, response.body
+  end
+
+  test '自分のメモを更新できる' do
+    sign_in @user
+
+    patch memo_url(@memo), params: {
+      memo: {
+        title: '更新後タイトル',
+        content: '更新後内容'
+      }
+    }
+
+    assert_redirected_to memo_url(@memo)
+
+    @memo.reload
+    assert_equal '更新後タイトル', @memo.title
+    assert_equal '更新後内容', @memo.content
+  end
+
+  test 'メモ更新に失敗した時、編集画面が再表示される' do
+    sign_in @user
+
+    patch memo_url(@memo), params: {
+      memo: {
+        title: '',
+        content: ''
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_select 'h2', text: 'メモ編集'
+
+    @memo.reload
+    assert_not_equal '', @memo.title
+  end
+
+  test '他人のメモ編集画面にはアクセスできない' do
+    sign_in @user
+
+    get edit_memo_url(@other_memo)
+    assert_response :not_found
+  end
+
+  test '他人のメモは更新できない' do
+    sign_in @user
+
+    patch memo_url(@other_memo), params: {
+      memo: {
+        title: '不正更新',
+        content: '不正更新'
+      }
+    }
+
+    assert_response :not_found
+
+    @other_memo.reload
+    assert_not_equal '不正更新', @other_memo.title
+  end
+
+  test '未ログイン時は編集画面にアクセスできずログイン画面へリダイレクトされる' do
+    get edit_memo_url(@memo)
+    assert_redirected_to new_user_session_url
+  end
+
+  test '未ログイン時は更新できずログイン画面へリダイレクトされる' do
+    patch memo_url(@memo), params: {
+      memo: {
+        title: '更新後タイトル',
+        content: '更新後内容'
+      }
+    }
+
+    assert_redirected_to new_user_session_url
+  end
+end


### PR DESCRIPTION
## 概要
メモ編集機能を実装し、既存メモの内容を更新できるようにしました。  
あわせて関連するテストを追加しました。

## 背景
メモ作成・詳細表示までは実装済みでしたが、既存メモを修正する機能が未実装だったため対応しました。  
Issue: #16 

## 変更内容
- メモ編集画面（edit）を追加
- メモ更新処理（update）を実装
- 詳細画面から編集画面への導線を追加
- 編集機能に対するテストを追加
- テストクラスの肥大化に伴い、テストファイルを分割

## 確認方法
- ログインする
- メモ一覧または詳細画面から「編集」を押す
- 編集画面が表示されることを確認
- タイトル・内容を変更して更新する
- 更新後、詳細画面に遷移し内容が反映されていることを確認
- 以下コマンドが成功することを確認
   - docker compose exec web rails test
   - docker compose exec web bundle exec rubocop

## 影響範囲
### 影響がある画面/機能
- メモ詳細画面
- メモ編集画面

### 影響がないこと
- メモ作成機能
- 認証機能（Devise）

## スクリーンショット
メモ編集画面
[![Image from Gyazo](https://i.gyazo.com/61be993cfc871ee6629a6119cd2ad5a8.png)](https://gyazo.com/61be993cfc871ee6629a6119cd2ad5a8)

メモ編集後のメモ詳細画面
[![Image from Gyazo](https://i.gyazo.com/ea967e0d6f30bd0ca66d2f066328e5ec.png)](https://gyazo.com/ea967e0d6f30bd0ca66d2f066328e5ec)

## 補足
テストの可読性向上のため、編集・更新処理のテストを別ファイルに分割しました。  
子メモ機能（ancestry）は今後の対応予定のため、本PRには含めていません。