### PR TITLE
子メモの作成と編集

### DIFF
--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -2,7 +2,7 @@
 
 class MemosController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_memo, only: %i[show edit update destroy]
+  before_action :set_memo, only: %i[show edit update destroy save_child]
 
   def index
     @memos = current_user.memos.includes(:user).order(created_at: :desc)
@@ -22,14 +22,19 @@ class MemosController < ApplicationController
     end
   end
 
-  def show; end
+  def show
+    @children = @memo.children
+  end
 
-  def edit; end
+  def edit
+    @child_memo = current_user.memos.new
+  end
 
   def update
     if @memo.update(memo_params)
       redirect_to memo_path(@memo), notice: 'メモを更新しました。'
     else
+      @child_memo = current_user.memos.new
       render :edit, status: :unprocessable_entity
     end
   end
@@ -39,13 +44,24 @@ class MemosController < ApplicationController
     redirect_to memos_path, notice: 'メモを削除しました。'
   end
 
-  private
+  def save_child
+    @child_memo = current_user.memos.new(memo_params)
+    @child_memo.parent = @memo
 
-  def memo_params
-    params.require(:memo).permit(:title, :content)
+    if @child_memo.save
+      redirect_to edit_memo_path(@memo), notice: '子メモを追加しました。'
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
+
+  private
 
   def set_memo
     @memo = current_user.memos.find(params[:id])
+  end
+
+  def memo_params
+    params.require(:memo).permit(:title, :content)
   end
 end

--- a/app/views/memos/_memo_tree.html.erb
+++ b/app/views/memos/_memo_tree.html.erb
@@ -1,0 +1,19 @@
+<div class="mb-8 rounded-xl bg-gray-50 p-4 text-gray-800">
+  <p class="mb-3 text-sm font-semibold text-gray-500">親子メモの確認</p>
+
+  <div class="flex mt-1">
+    <p class="font-semibold"><%= @memo.title %></p>
+    <p class="text-gray-700">：<%= simple_format(@memo.content) %>
+  </div>
+
+  <% if @memo.children.any? %>
+    <div class="mt-4 space-y-3">
+      <% @memo.children.each do |child| %>
+        <div class="flex ml-6 border-l-2 border-gray-300 pl-4">
+          <p class="font-semibold text-gray-800"><%= child.title %></p>
+          <p class="text-gray-700">：<%= simple_format(child.content) %></p>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/memos/edit.html.erb
+++ b/app/views/memos/edit.html.erb
@@ -2,6 +2,10 @@
   <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
     <h2 class="mb-6 text-2xl font-bold text-gray-800">メモ編集</h2>
 
+    <div class="mb-8">
+      <%= render "memo_tree", memo: @memo %>
+    </div>
+
     <% if @memo.errors.any? %>
       <div class="mb-4 rounded-lg bg-red-50 p-4 text-red-700">
         <p class="font-semibold"><%= pluralize(@memo.errors.count, "error") %> <%= @memo.errors.count %>件のエラーがあります。</p>
@@ -29,5 +33,33 @@
         <%= link_to "戻る", memo_path(@memo), class: "rounded-lg border border-gray-300 px-4 py-2 font-semibold text-gray-700 hover:bg-gray-50" %>
       </div>
     <% end %>
+
+    <div class="mt-8 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+      <h3 class="mb-4 text-xl font-bold text-gray-800">子メモを追加</h3>
+      <% if @child_memo&.errors&.any? %>
+        <div class="mb-4 rounded-lg bg-red-50 p-4 text-red-700">
+          <p class="font-semibold">子メモに<%= @child_memo.errors.count %>件のエラーがあります。</p>
+          <ul class="mt-2 list-disc pl-5">
+            <% @child_memo.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <%= form_with model: @child_memo, url: save_child_memo_path(@memo), local: true do |f| %>
+        <div class="mb-4">
+          <%= f.label :title, "タイトル", class: "mb-2 block text-sm font-semibold text-gray-700" %>
+          <%= f.text_field :title, class: "w-full rounded-lg border border-gray-300 px-3 py-2" %>
+        </div>
+
+        <div class="mb-4">
+          <%= f.label :content, "内容", class: "mb-2 block text-sm font-semibold text-gray-700" %>
+          <%= f.text_area :content, rows: 4, class: "w-full rounded-lg border border-gray-300 px-3 py-2" %>
+        </div>
+
+        <%= f.submit "子メモを追加", class: "rounded-lg bg-green-600 px-4 py-2 font-semibold text-white hover:bg-green-700" %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -4,19 +4,18 @@
 
     <div class="mb-6">
       <p class="mb-2 text-sm font-semibold text-gray-500">タイトル：内容</p>
-      <div class="rounded-xl bg-gray-50 p-4 text-gray-800 leading-relaxed">
-        <%= simple_format(@memo.title + "：" + @memo.content) %>
-      </div>
+      <%= render "memo_tree", memo: @memo %>
     </div>
+
 
     <div class="mb-6 space-y-2 text-sm text-gray-600">
       <p>作成日時: <%= l @memo.created_at, format: :short %></p>
       <p>更新日時: <%= l @memo.updated_at, format: :short %></p>
     </div>
 
-    <div class="mt-4 flex gap-3 border-t border-gray-200 pt-4">
-      <%= link_to "編集", edit_memo_path(@memo), class: "inline-block rounded-lg bg-yellow-500 px-4 py-2 font-semibold text-white hover:bg-yellow-600" %>
-      <%= link_to "一覧へ戻る", memos_path, class: "inline-block rounded-lg bg-blue-600 px-4 py-2 font-semibold text-white hover:bg-blue-700" %>
+    <div class="flex gap-3 border-t border-gray-200 pt-4">
+      <%= link_to "編集", edit_memo_path(@memo), class: "rounded-lg bg-yellow-500 px-4 py-2 font-semibold text-white hover:bg-yellow-600" %>
+      <%= link_to "一覧へ戻る", memos_path, class: "rounded-lg bg-blue-600 px-4 py-2 font-semibold text-white hover:bg-blue-700" %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,9 @@ Rails.application.routes.draw do
 
   root 'homes#index'
 
-  resources :memos
+  resources :memos do
+    member do
+      post :save_child
+    end
+  end
 end

--- a/test/controllers/memos_controller_test.rb
+++ b/test/controllers/memos_controller_test.rb
@@ -97,4 +97,19 @@ class MemosControllerTest < ActionDispatch::IntegrationTest
     get memo_url(@memo)
     assert_redirected_to new_user_session_url
   end
+
+  test 'メモ詳細画面に子メモが表示される' do
+    sign_in @user
+
+    child_memo = @memo.children.create!(
+      user: @user,
+      title: '子メモタイトル',
+      content: '子メモ内容'
+    )
+
+    get memo_url(@memo)
+    assert_response :success
+    assert_match child_memo.title, response.body
+    assert_match child_memo.content, response.body
+  end
 end

--- a/test/controllers/memos_edit_update_test.rb
+++ b/test/controllers/memos_edit_update_test.rb
@@ -93,4 +93,19 @@ class MemosEditUpdateTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to new_user_session_url
   end
+
+  test 'メモ編集画面に子メモが表示される' do
+    sign_in @user
+
+    child_memo = @memo.children.create!(
+      user: @user,
+      title: '子メモタイトル',
+      content: '子メモ内容'
+    )
+
+    get edit_memo_url(@memo)
+    assert_response :success
+    assert_match child_memo.title, response.body
+    assert_match child_memo.content, response.body
+  end
 end

--- a/test/controllers/memos_tree_display_test.rb
+++ b/test/controllers/memos_tree_display_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MemosTreeDisplayTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = users(:one)
+    @memo = memos(:one)
+  end
+
+  test 'メモ詳細画面に複数の子メモが表示される' do
+    sign_in @user
+
+    child1 = @memo.children.create!(
+      user: @user,
+      title: '子メモ1',
+      content: '子メモ内容1'
+    )
+
+    child2 = @memo.children.create!(
+      user: @user,
+      title: '子メモ2',
+      content: '子メモ内容2'
+    )
+
+    get memo_url(@memo)
+    assert_response :success
+    assert_match child1.title, response.body
+    assert_match child1.content, response.body
+    assert_match child2.title, response.body
+    assert_match child2.content, response.body
+  end
+end


### PR DESCRIPTION
## 概要

親メモと子メモの表示を共通化し、詳細画面および編集画面で親子関係を確認できるようにしました。  
あわせて子メモ表示に関するテストを追加しました。

## 背景

子メモ作成機能の実装に伴い、どの親メモに対して子メモが追加されているかを画面上で分かりやすくする必要がありました。  
また、詳細画面と編集画面で同様の表示ロジックが発生したため共通化を行いました。  
Issue #18 

## 変更内容
- 親メモと子メモを表示する部分テンプレート（_memo_tree.html.erb）を作成
- 詳細画面に親子メモ表示を追加
- 編集画面の上部に親子メモ表示を追加
- 子メモ表示に関するテストを追加
- テストクラスの責務を整理し、ファイルを分割

## 確認方法
- ログインする
- メモ詳細画面を開き、親メモの下に子メモが表示されることを確認
- メモ編集画面を開き、上部に親子メモが表示されることを確認
- 編集画面から子メモを追加し、追加後に画面上で反映されることを確認
- 以下コマンドが成功することを確認
   - docker compose exec web rails test
   - docker compose exec web bundle exec rubocop

## 影響範囲
### 影響がある画面/機能
- メモ詳細画面
- メモ編集画面

### 影響がないこと
- メモ作成機能
- 認証機能（Devise）

## スクリーンショット
メモ詳細画面  
[![Image from Gyazo](https://i.gyazo.com/bbaa92563a128470a98c1b1f0e7319e1.png)](https://gyazo.com/bbaa92563a128470a98c1b1f0e7319e1)  

メモ編集画面（上部）  
[![Image from Gyazo](https://i.gyazo.com/bd92d79faf9b18a85da1fba18ef2c305.png)](https://gyazo.com/bd92d79faf9b18a85da1fba18ef2c305)

メモ編集画面（下部）  
[![Image from Gyazo](https://i.gyazo.com/2d37b6470cf526a02aaa76515c5edd00.png)](https://gyazo.com/2d37b6470cf526a02aaa76515c5edd00)

## 補足
親子メモ表示は今後のツリー構造（多階層）表示への拡張を見据えた実装としています。