### PR TITLE
ヘルスチェック用エンドポイント追加

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,6 @@ Rails.application.routes.draw do
     end
     resources :generated_texts, only: %i[index create show]
   end
+
+  get "/up", to: proc { [200, { "Content-Type" => "text/plain" }, ["OK"]] }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,5 +15,5 @@ Rails.application.routes.draw do
     resources :generated_texts, only: %i[index create show]
   end
 
-  get "/up", to: proc { [200, { "Content-Type" => "text/plain" }, ["OK"]] }
+  get '/up', to: proc { [200, { 'Content-Type' => 'text/plain' }, ['OK']] }
 end


### PR DESCRIPTION
## 概要
Render無料プラン向けの応急対応として、ヘルスチェック用エンドポイントを追加し、keep-aliveのアクセス先を軽量化しました。

## 背景
GASで定期的にトップページへアクセスしていたところ、521 / 522 / 503 / 429 が発生しており、Render起動時の負荷や制限の影響を受けている可能性があったため、応急対応が必要となった。

## 変更内容
- `config/routes.rb` にヘルスチェック用の `/up` エンドポイントを追加
- `/up` ではDBや通常画面描画を行わず、軽量なレスポンスのみ返す構成に変更
- keep-alive用アクセス先をトップページ `/` から `/up` に見直す前提で調整

## 確認方法
1. ローカル環境で `/up` にアクセスする
2. `OK` など想定したレスポンスが返ることを確認する
3. 本番環境でも `/up` にアクセスし、正常に200系レスポンスが返ることを確認する
4. 既存のトップページや主要機能に影響がないことを確認する

## 影響範囲
- 影響がある画面/機能
  - ヘルスチェック用エンドポイント
  - keep-alive運用
- 影響がないこと
  - トップページ表示
  - メモ機能（CRUD）
  - AI生成機能
  - ログイン機能

## 補足
Render無料プランではスリープや起動遅延の影響を受けやすいため、トップページではなく軽量なヘルスチェック用URLを利用する方針とした。  
今後はGAS側のアクセス先変更後に、429等の発生状況が改善するか継続確認する。