### PR TITLE
AI処理画面のレスポンシブ対応

### DIFF
--- a/app/views/memos/_ai_result.html.erb
+++ b/app/views/memos/_ai_result.html.erb
@@ -7,7 +7,7 @@
     <%= form_with url: memo_generated_texts_path(@memo), method: :post, scope: :generated_text, local: true do |f| %>
       <%= f.hidden_field :kind, value: @tab %>
       <%= f.hidden_field :content, value: @result %>
-      <%= f.submit "生成結果を保存する", class:"rounded-lg bg-green-600 px-4 py-2 font-semibold text-white hover:bg-green-700" %>
+      <%= f.submit "生成結果を保存する", class:"w-full rounded-lg bg-green-600 px-4 py-2 font-semibold text-white hover:bg-green-700 sm:w-auto" %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/memos/_memo_node.html.erb
+++ b/app/views/memos/_memo_node.html.erb
@@ -1,22 +1,23 @@
 <% is_current = memo == current_memo %>
 
-<div class="<%= depth.zero? ? '' : 'ml-6 mt-4 border-l-2 border-gray-300 pl-4' %>">
-  <div id="<%= dom_id(memo) %>" class="rounded-lg p-2 <%= is_current ? 'current-memo bg-yellow-50 border border-yellow-400' : '' %>">
-    <div class="flex items-start justify-between gap-3">
-      <div>
-        <p class="font-semibold text-gray-800">
+<div class="<%= depth.zero? ? '' : 'ml-3 mt-4 border-l-2 border-gray-300 pl-3 sm:ml-6 sm:pl-4' %>">
+ <div id="<%= dom_id(memo) %>" class="rounded-lg p-3 sm:p-2 <%= is_current ? 'current-memo bg-yellow-50 border border-yellow-400' : '' %>">
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div class="min-w-0">
+        <p class="wrap-break-word font-semibold text-gray-800">
           <%= memo.title %>
           <% if is_current %>
-            <span class="ml-2 rounded bg-yellow-200 px-2 py-0.5 text-xs font-semibold text-yellow-800">編集中</span>
+            <span class="ml-2 inline-block rounded bg-yellow-200 px-2 py-0.5 text-xs font-semibold text-yellow-800">編集中</span>
           <% end %>
         </p>
-        <div class="mt-1 text-gray-700">
+
+        <div class="mt-1 wrap-break-word text-sm text-gray-700 sm:text-base">
           <%= simple_format(memo.content) %>
         </div>
       </div>
 
-      <div class="shrink-0">
-        <%= link_to "編集", edit_memo_path(memo), class: "rounded-lg bg-yellow-500 px-3 py-2 text-sm font-semibold text-white hover:bg-yellow-600" %>
+      <div class="flex shrink-0 justify-end">
+        <%= link_to "編集", edit_memo_path(memo), class: "block w-full rounded-lg bg-yellow-500 px-3 py-2 text-sm text-center font-semibold text-white hover:bg-yellow-600 sm:w-auto" %>
       </div>
     </div>
   </div>

--- a/app/views/memos/ai_tools.html.erb
+++ b/app/views/memos/ai_tools.html.erb
@@ -1,5 +1,5 @@
-<div class="mx-auto max-w-3xl px-4 py-8">
-  <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+<div class="mx-auto max-w-3xl px-4 py-6 sm:py-8">
+  <div class="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6">
     <p class="mb-1 text-sm text-gray-500">AI処理</p>
     <h2 class="mb-1 text-2xl leading-tight font-bold text-gray-800"><%= @memo.title %></h2>
     <p class="mb-6 text-sm text-gray-500">このメモをもとにAI整理・要約・文章生成を行います</p>
@@ -11,18 +11,18 @@
       </p>
     </div>
 
-    <div class="mb-6 flex gap-2 border-b border-gray-200">
+    <div class="mb-6 flex flex-wrap gap-2 border-b border-gray-200">
       <%= link_to "AI整理",
           ai_tools_memo_path(@memo, tab: "organize"),
-          class: "px-4 py-2 text-sm font-medium rounded-t-lg #{@tab == 'organize' ? 'bg-green-100 text-green-700 border border-b-0 border-gray-200' : 'text-gray-600 hover:text-gray-800'}" %>
+          class: "rounded-t-lg px-3 py-2 text-sm font-medium sm:px-4 #{@tab == 'organize' ? 'bg-green-100 text-green-700 border border-b-0 border-gray-200' : 'text-gray-600 hover:text-gray-800'}" %>
 
       <%= link_to "AI要約",
           ai_tools_memo_path(@memo, tab: "summary"),
-          class: "px-4 py-2 text-sm font-medium rounded-t-lg #{@tab == 'summary' ? 'bg-green-100 text-green-700 border border-b-0 border-gray-200' : 'text-gray-600 hover:text-gray-800'}" %>
+          class: "rounded-t-lg px-3 py-2 text-sm font-medium sm:px-4 #{@tab == 'summary' ? 'bg-green-100 text-green-700 border border-b-0 border-gray-200' : 'text-gray-600 hover:text-gray-800'}" %>
 
       <%= link_to "文章生成",
           ai_tools_memo_path(@memo, tab: "writing"),
-          class: "px-4 py-2 text-sm font-medium rounded-t-lg #{@tab == 'writing' ? 'bg-green-100 text-green-700 border border-b-0 border-gray-200' : 'text-gray-600 hover:text-gray-800'}" %>
+          class: "rounded-t-lg px-3 py-2 text-sm font-medium sm:px-4 #{@tab == 'writing' ? 'bg-green-100 text-green-700 border border-b-0 border-gray-200' : 'text-gray-600 hover:text-gray-800'}" %>
     </div>
 
     <div class="mb-6 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-700">
@@ -62,9 +62,9 @@
               ["箇条書き", "bullet"],
               ["番号付き", "numbered"],
               ["絵文字付き", "emoji"]
-            ], @tab),
+            ], params[:format_type]),
             include_blank: "選択してください",
-            class: "rounded-lg border border-gray-300 px-3 py-2" %>
+            class: "w-full rounded-lg border border-gray-300 px-3 py-2 sm:w-auto" %>
         </div>
       <% end %>
 
@@ -73,30 +73,30 @@
           <%= label_tag :format_type, "文章の種類", class: "mb-1 block text-sm font-medium text-gray-700" %>
           <%= select_tag :format_type,
               options_for_select([["日報", "daily_report"], ["相談文", "consultation"], ["報告文", "report"]]),
-              class: "w-full rounded-lg border border-gray-300 px-3 py-2" %>
+              class: "w-full rounded-lg border border-gray-300 px-3 py-2 sm:w-auto" %>
         </div>
 
         <div class="mb-6">
           <%= label_tag :tone, "文体", class: "mb-1 block text-sm font-medium text-gray-700" %>
           <%= select_tag :tone,
-              options_for_select([["丁寧", "formal"], ["ややカジュアル", "casual"]]),
-              class: "w-full rounded-lg border border-gray-300 px-3 py-2" %>
+              options_for_select([["丁寧", "polite"], ["ややカジュアル", "casual"]]),
+              class: "w-full rounded-lg border border-gray-300 px-3 py-2 sm:w-auto" %>
         </div>
       <% end %>
 
-      <%= f.submit "生成する", 
-          class: "rounded-lg bg-green-600 px-4 py-2 font-semibold text-white hover:bg-green-700" %>
+      <%= f.submit "生成する",
+        class: "w-full rounded-lg bg-green-600 px-4 py-2 font-semibold text-white hover:bg-green-700 sm:w-auto" %>
     <% end %>
 
     <div id="ai_result">
       <%= render "memos/ai_result", result: @result %>
     </div>
 
-    <div class="mt-6 flex justify-end gap-3">
+    <div class="mt-8 flex flex-col justify-end gap-3 sm:flex-row sm:flex-wrap sm:justify-end">
       <%= link_to "メモ一覧へ戻る", memos_path,
-          class: "rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50" %>
+          class: "w-full rounded-lg border border-gray-300 px-4 py-2 text-center text-sm font-medium text-gray-700 hover:bg-gray-50 sm:w-auto" %>
       <%= link_to "メモ詳細に戻る", memo_path(@memo),
-          class: "rounded-lg bg-gray-200 px-4 py-2 text-gray-800 font-semibold hover:bg-gray-300" %>
+          class: "w-full rounded-lg bg-gray-200 px-4 py-2 text-center text-gray-800 font-semibold hover:bg-gray-300 sm:w-auto" %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 概要
AI処理画面のレスポンシブ対応を行い、スマートフォン表示時のレイアウトと操作性を改善しました。

## 背景
スマートフォン表示時に、AI処理画面のタブ・フォーム・ボタン配置に詰まりや操作しづらさがあったため、画面幅に応じたレイアウト調整が必要だった。
（Issue: #101）

## 変更内容
- AI処理画面の余白・カード内paddingをスマホ向けに調整
- AI整理 / AI要約 / 文章生成タブの横幅調整と折り返し対応
- 生成ボタンをスマホでは押しやすい全幅表示に変更
- 戻るボタンをスマホでは縦並び・全幅表示に変更
- メモツリー表示のインデント・文字サイズ・編集ボタン配置をスマホ向けに調整
- 生成ボタンと戻るボタンの間に余白を設け、操作グループを分かりやすく整理

## 確認方法
- AI処理画面をスマホ幅で表示し、横スクロールが発生しないことを確認
- AI整理 / AI要約 / 文章生成タブが押しやすく表示されることを確認
- 整理スタイル・文章の種類・文体のプルダウンが画面幅に収まることを確認
- 生成ボタン・戻るボタンがスマホ幅で押しやすく表示されることを確認
- PC表示で既存レイアウトが大きく崩れていないことを確認
- 以下コマンドが通ることを確認
```bash
  bundle exec rspec
  bundle exec rubocop
```

## 影響範囲
### 影響がある画面
- AI処理画面
- AI処理画面内の元メモツリー表示

### 影響がないこと
- AI整理・AI要約・文章生成の処理ロジック
- メモ一覧画面
- メモ詳細画面
- 生成履歴画面


## スクリーンショット
[![Image from Gyazo](https://i.gyazo.com/945126ec7f5d2f68bcaee33f8a68bf2e.png)](https://gyazo.com/945126ec7f5d2f68bcaee33f8a68bf2e)

[![Image from Gyazo](https://i.gyazo.com/6124830c97296f0dd7a3b87bbf8802f3.png)](https://gyazo.com/6124830c97296f0dd7a3b87bbf8802f3)

[![Image from Gyazo](https://i.gyazo.com/4da3255b8e4b454f6331ed3de63bcc2f.jpg)](https://gyazo.com/4da3255b8e4b454f6331ed3de63bcc2f)

[![Image from Gyazo](https://i.gyazo.com/2a96c9d285c4c4be45ea9036bcec368b.png)](https://gyazo.com/2a96c9d285c4c4be45ea9036bcec368b)

## 補足
- 今回はAI処理画面に限定してレスポンシブ対応を実施
- 表示調整のみのため、新規テストコードの追加は行っていない
- 他画面のレスポンシブ対応は別Issueで対応予定