### PR TITLE
メモ一覧のレスポンシブ対応

### DIFF
--- a/app/views/memos/_memo_list_tree.html.erb
+++ b/app/views/memos/_memo_list_tree.html.erb
@@ -2,37 +2,49 @@
   <div class="flex items-center justify-between gap-4">
     <button
       type="button"
-      class="flex items-center gap-2 text-left font-semibold text-gray-800"
+      class="flex min-w-0 items-center gap-2 text-left font-semibold text-gray-800"
       data-action="click->tree-toggle#toggle"
     >
       <% if memo.children.any? %>
-        <span data-tree-toggle-target="icon">▶</span>
+        <span class="shrink-0" data-tree-toggle-target="icon">▶</span>
       <% else %>
-        <span class="w-4"></span>
+        <span class="w-4 shrink-0"></span>
       <% end %>
-      <span><%= memo.title %></span>
+      <span class="wrap-break-word">
+        <%= memo.title %>
+      </span>
     </button>
 
+    <%# PC用：右上に表示 %>
     <%= link_to "詳細", memo_path(memo),
-        class: "rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-blue-700" %>
+        class: "hidden rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-blue-700 sm:inline-block" %>
   </div>
 
   <% if memo.children.any? %>
-    <div class="mt-4 space-y-3 hidden" data-tree-toggle-target="children">
+    <div class="mt-4 mb-4 space-y-3 hidden" data-tree-toggle-target="children">
       <% memo.children.each do |child| %>
         <%= render "memo_list_node", memo: child %>
       <% end %>
     </div>
   <% end %>
-  <p class="text-sm text-gray-500 mb-2">
+
+  <div class="mt-3 text-sm text-gray-500 sm:mb-2">
     <% if memo.tags.any? %>
       <div class="flex flex-wrap gap-2">
         <% memo.tags.each do |tag| %>
-          <%= link_to tag.name, memos_path(tag: tag.name), class: "inline-block rounded-full bg-blue-100  px-3 py-1 text-xs text-blue-500" %>
+          <%= link_to tag.name,
+              memos_path(tag: tag.name),
+              class: "inline-block max-w-full break-words rounded-full bg-blue-100 px-3 py-1 text-xs text-blue-500" %>
         <% end %>
       </div>
     <% else %>
       <p class="text-sm text-gray-400">タグはまだありません</p>
     <% end %>
-  </p>
+  </div>
+
+  <%# スマホ用：タグの下に表示 %>
+  <div class="mt-3 sm:hidden">
+    <%= link_to "詳細", memo_path(memo),
+        class: "block w-full rounded-lg bg-blue-600 px-3 py-2 text-center text-sm font-semibold text-white hover:bg-blue-700" %>
+  </div>
 </div>

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -1,7 +1,7 @@
-<div class="mx-auto max-w-4xl px-4 py-8">
+<div class="mx-auto max-w-4xl px-4 py-6 sm:py-8">
   <div class="mx-auto max-w-3xl">
-    <div class="mb-6 rounded-2xl bg-white p-6 shadow-md">
-      <h2 class="mb-1 text-2xl font-bold text-gray-800">
+    <div class="mb-6 rounded-2xl bg-white p-4 shadow-md sm:p-6">
+      <h2 class="mb-1 text-xl font-bold text-gray-800 sm:text-2xl">
         こんにちは、<%= current_user.name %>さん
       </h2>
       <p class="mb-4 text-sm font-medium text-gray-500">ホーム</p>
@@ -12,11 +12,12 @@
           <%= link_to "解除", memos_path, class: "ml-2 underline hover:text-blue-600" %>
         </div>
       <% end %>
-      <div class="flex gap-3">
+
+      <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
         <%= link_to "新規メモ作成", new_memo_path,
-            class: "rounded-lg bg-green-600 px-4 py-2 text-white font-semibold hover:bg-green-700" %>
+            class: "w-full rounded-lg bg-green-600 px-4 py-2 text-center font-semibold text-white hover:bg-green-700 sm:w-auto" %>
         <%= link_to "全保存履歴を見る", generated_texts_path,
-            class: "rounded-lg bg-blue-400 px-4 py-2 font-semibold text-white hover:bg-blue-500" %>
+            class: "w-full rounded-lg bg-blue-400 px-4 py-2 text-center font-semibold text-white hover:bg-blue-500 sm:w-auto" %>
       </div>
     </div>
 


### PR DESCRIPTION
## 概要
メモ一覧画面のレスポンシブ対応について実機確認を行い、現状の実装で問題がないことを確認しました。

## 背景
メモ一覧画面において、タグ増加時やスマートフォン表示時のレイアウト崩れが懸念されたため、レスポンシブ対応の必要性を検討するためのIssueを作成しました。
（ Issue #103 ）

## 変更内容
- 親メモを開いた時の線の長さを調整
- タグの間隔と折り返しを調整
- スマホ側の詳細ボタンをタグの下に配置
- メモ一覧画面をスマートフォン実機で確認
- レイアウト・操作性の観点から問題がないことを確認

## 確認方法
- スマートフォン実機でメモ一覧画面を表示し、以下を確認
  - タグが折り返し表示されること
  - 「詳細」ボタンが押しやすい位置に配置されていること
  - 横スクロールが発生していないこと
  - タイトル・タグ・ボタンの配置が自然であること
  
## 影響範囲
### 影響があるもの
- メモ一覧画面の見た目

### 影響がないこと
- メモ一覧画面の動作
- その他全ての機能

## スクリーンショット
[![Image from Gyazo](https://i.gyazo.com/59b5d5d0e185092735b8e9f6958c7b09.jpg)](https://gyazo.com/59b5d5d0e185092735b8e9f6958c7b09)

[![Image from Gyazo](https://i.gyazo.com/6e80d6180921030119ef202c81697834.jpg)](https://gyazo.com/6e80d6180921030119ef202c81697834)

## 補足
今後タグ機能の拡張等を行う場合は、再度レスポンシブ対応を検討する