### PR TITLE
ログインまわりのレスポンシブ対応

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -49,7 +49,7 @@
 
       <div class="text-center">
         <%= f.submit "新規登録",
-            class: "inline-block rounded-lg bg-green-600 px-6 py-3 text-white font-semibold hover:bg-green-700" %>
+            class: "w-full inline-block rounded-lg bg-green-600 px-6 py-3 text-white font-semibold hover:bg-green-700 sm:w-auto" %>
       </div>
     <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -20,15 +20,15 @@
       </div>
 
       <% if devise_mapping.rememberable? %>
-        <div class="mb-6 flex items-center gap-2 text-sm text-gray-700">
-          <%= f.check_box :remember_me %>
-          <%= f.label :remember_me, "ログイン状態を保持する" %>
-        </div>
+        <label class="flex items-center gap-3 cursor-pointer">
+          <%= f.check_box :remember_me, class: "h-5 w-5" %>
+          <span class="text-sm text-gray-700">ログイン状態を保持する</span>
+        </label>
       <% end %>
 
-      <div class="text-center">
+      <div class="mt-6 text-center">
         <%= f.submit "ログイン",
-            class: "inline-block rounded-lg bg-blue-600 px-6 py-3 text-white font-semibold hover:bg-blue-700" %>
+            class: "w-full inline-block rounded-lg bg-blue-600 px-6 py-3 text-white font-semibold hover:bg-blue-700 sm:w-auto" %>
       </div>
     <% end %>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <p><%= link_to "初めて利用する方はこちら", new_registration_path(resource_name), class: "text-blue-600 hover:underline" %></p>
+  <p class="mb-2"><%= link_to "初めて利用する方はこちら", new_registration_path(resource_name), class: "text-blue-600 hover:underline" %></p>
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -10,15 +10,15 @@
 
     <div class="mt-10 grid grid-cols-1 gap-6 md:grid-cols-2">
       <div class="rounded-xl border border-gray-200 p-6 text-center">
-        <p class="mb-4 text-sm text-gray-500">すでにアカウントをお持ちの方はこちら</p>
+        <p class="mb-4 text-sm text-gray-500">アカウントをお持ちの方はこちら</p>
         <%= link_to "ログイン", new_user_session_path,
-            class: "inline-block rounded-lg bg-blue-600 px-6 py-3 text-white font-semibold hover:bg-blue-700" %>
+            class: "w-full inline-block rounded-lg bg-blue-600 px-6 py-3 text-white font-semibold hover:bg-blue-700 sm:w-auto" %>
       </div>
 
       <div class="rounded-xl border border-gray-200 p-6 text-center">
         <p class="mb-4 text-sm text-gray-500">初めて利用する方はこちら</p>
         <%= link_to "新規登録", new_user_registration_path,
-            class: "inline-block rounded-lg bg-green-600 px-6 py-3 text-white font-semibold hover:bg-green-700" %>
+            class: "w-full inline-block rounded-lg bg-green-600 px-6 py-3 text-white font-semibold hover:bg-green-700 sm:w-auto" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要
トップページ・ログイン画面・新規登録画面のレスポンシブ対応および操作性改善を行いました。

## 背景

スマートフォン表示時に、文言の折り返しやボタンのタップ領域、チェックボックスの操作性に課題があったため、初回利用時のユーザー体験向上を目的として対応を行いました。
（ Issue #105 ）

## 変更内容
-トップページの文言を調整（不自然な改行の解消）
- ログイン・新規登録画面のボタン幅をスマホでは全幅表示に変更
  - w-full sm:w-auto を適用
- 「ログイン状態を保持する」のチェックボックスの操作性改善
  - ラベル全体をクリック可能に変更
- チェックボックスのサイズ調整（h-5 w-5）
- 各ボタン・フォーム要素の余白および配置をスマホ向けに調整

## 確認方法
- スマートフォン表示でトップページ・ログイン画面・新規登録画面を確認
- 以下を確認
  - 文言が不自然に折り返されていないこと
  - ボタンがタップしやすい幅になっていること
  - チェックボックスがラベル含めて押しやすいこと
  - 横スクロールが発生していないこと
- PC表示でレイアウトが大きく崩れていないことを確認
- 以下コマンドが通ることを確認
```
bundle exec rspec
bundle exec rubocop
```

## 影響範囲
### 影響がある画面
- トップページ
- ログイン画面
- 新規登録画面

### 影響がないこと
- 認証処理のロジック
- メモ機能全般
- AI処理機能

## スクリーンショット
- トップページ
[![Image from Gyazo](https://i.gyazo.com/57f023b7dd49d7720319616cf784a6ed.jpg)](https://gyazo.com/57f023b7dd49d7720319616cf784a6ed)

- ログイン画面
[![Image from Gyazo](https://i.gyazo.com/2c1a59f451b7fcf939464dd8a54020cd.jpg)](https://gyazo.com/2c1a59f451b7fcf939464dd8a54020cd)

- 新規登録画面
[![Image from Gyazo](https://i.gyazo.com/7c424db766317613ca001c5f78b4c27d.jpg)](https://gyazo.com/7c424db766317613ca001c5f78b4c27d)

## 補足
- 初回利用時のUX改善を目的とした対応
- レスポンシブ対応の一環として実施
- メモ詳細画面など他画面の対応は別Issueで実施予定