### PR TITLE
メモ詳細画面のレスポンシブ対応

### DIFF
--- a/app/views/memos/_memo_node.html.erb
+++ b/app/views/memos/_memo_node.html.erb
@@ -1,7 +1,7 @@
 <% is_current = memo == current_memo %>
 
-<div class="<%= depth.zero? ? '' : 'ml-3 mt-4 border-l-2 border-gray-300 pl-3 sm:ml-6 sm:pl-4' %>">
- <div id="<%= dom_id(memo) %>" class="rounded-lg p-3 sm:p-2 <%= is_current ? 'current-memo bg-yellow-50 border border-yellow-400' : '' %>">
+<div class="<%= depth.zero? ? '' : 'ml-2 mt-4 border-l border-gray-300 pl-2 sm:ml-6 sm:border-l-2 sm:pl-4' %>">
+  <div id="<%= dom_id(memo) %>" class="rounded-lg p-3 sm:p-2 <%= is_current ? 'current-memo bg-yellow-50 border border-yellow-400' : '' %>">
     <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
       <div class="min-w-0">
         <p class="wrap-break-word font-semibold text-gray-800">

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -1,31 +1,35 @@
 <div class="mx-auto max-w-3xl px-4 py-8">
   <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-    <div class="mb-6 flex justify-between">
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:mb-6">
       <h2 class="text-2xl font-bold text-gray-800">メモ詳細</h2>
-      <div class="flex  gap-3">
-        <%= link_to "AI処理", ai_tools_memo_path(@memo), class: "rounded-lg bg-blue-600 px-4 py-2 font-semibold text-white hover:bg-blue-700" %>
-        <%= link_to "生成結果保存履歴", memo_generated_texts_path(@memo), class: "rounded-lg bg-blue-400 px-4 py-2 font-semibold text-white hover:bg-blue-600" %>
+      <div class="mb-4 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:gap-3 sm:mb-0">
+        <%= link_to "AI処理", ai_tools_memo_path(@memo), class: "w-full rounded-lg bg-blue-600 px-4 py-2 font-semibold text-center text-white hover:bg-blue-700 sm:w-auto" %>
+        <%= link_to "生成結果保存履歴", memo_generated_texts_path(@memo), class: "w-full rounded-lg bg-blue-400 px-4 py-2 font-semibold text-center text-white hover:bg-blue-600 sm:w-auto" %>
         <%= link_to "このメモを削除", memo_path(@memo),
         data: {
           turbo_method: :delete,
           turbo_confirm: @memo.children.any? ? "子メモもまとめて削除されます。本当に削除しますか？" : "本当に削除しますか？"
         },
-        class: "rounded-lg bg-red-600 px-4 py-2 font-semibold text-white hover:bg-red-700" %>
+        class: "mt-4 w-full rounded-lg bg-red-600 px-4 py-2 font-semibold text-center text-white hover:bg-red-700 sm:w-auto sm:mt-0" %>
       </div>
     </div>
 
     <div class="mb-6">
       <p class="mb-2 text-sm font-semibold text-gray-500">タイトル：内容</p>
       <%= render "memo_tree", memo: @tree_root, current_memo: nil %>
-      <p class="text-sm text-gray-500 mb-2">
+      <div class="mb-2 text-sm text-gray-500">
         <% if @memo.tags.any? %>
-          <% @memo.tags.each do |tag| %>
-            <%= link_to tag.name, memos_path(tag: tag.name), class: "inline-block rounded-full bg-blue-100  px-3 py-1 text-xs text-blue-500" %>
-          <% end %>
+          <div class="flex flex-wrap gap-2">
+            <% @memo.tags.each do |tag| %>
+              <%= link_to tag.name,
+                  memos_path(tag: tag.name),
+                  class: "inline-block max-w-full wrap-break-word rounded-full bg-blue-100 px-3 py-1 text-xs text-blue-500" %>
+            <% end %>
+          </div>
         <% else %>
           <p class="text-sm text-gray-400">タグはまだありません</p>
         <% end %>
-      </p>
+      </div>
     </div>
 
 
@@ -34,9 +38,9 @@
       <p>更新日時: <%= l @memo.updated_at, format: :short %></p>
     </div>
 
-    <div class="flex border-t border-gray-200 pt-4">
+    <div class="flex flex-wrap border-t border-gray-200 pt-4">
       <%= link_to "メモ一覧へ戻る", memos_path,
-          class: "rounded-lg bg-gray-200 px-4 py-2 text-gray-800 font-semibold hover:bg-gray-300" %>
+          class: "w-full sm:w-auto rounded-lg bg-gray-200 px-4 py-2 text-center text-gray-800 font-semibold hover:bg-gray-300" %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 概要
メモ詳細画面のレスポンシブ対応を行い、スマートフォン表示時のレイアウトおよび操作性を改善しました。

## 背景
メモ詳細画面ではツリー構造の表示や複数ボタンの配置があり、スマートフォン表示時にレイアウトの崩れや操作性低下が懸念されたため、レスポンシブ対応を実施しました。
（Issue #107 ）

## 変更内容
- ツリー構造のインデントをスマホでは浅く調整（ml-2 / pl-2）
- タイトル・本文に折り返し対応を適用
- 編集ボタンをスマホでは全幅表示に変更（w-full sm:w-auto）
- 上部ボタン（AI処理 / 履歴 / 削除）をスマホでは縦並びに変更
- 削除ボタンのみ余白を設け、誤タップ防止の配慮を追加
- タグ表示を flex-wrap に変更し、スマホでも自然に折り返されるよう修正
- 全体の余白・配置をデバイスごとに調整

## 確認方法
- スマートフォン表示でメモ詳細画面を確認し、以下を確認
- 横スクロールが発生していないこと
- ツリー構造が視認しやすいこと
- ボタンがタップしやすい配置・サイズであること
- 削除ボタンが他ボタンと分離されていること
- タグが自然に折り返されること
- PC表示で既存レイアウトが崩れていないことを確認
- 以下コマンドが通ることを確認
```
bundle exec rspec
bundle exec rubocop
```

## 影響範囲
### 影響がある画面
- メモ詳細画面
- メモツリー表示（部分テンプレート）
-  メモ一覧画面
- AI処理画面

## 影響がないこと
- メモ一覧画面
- 認証画面（ログイン・新規登録）
- AI処理ロジック・メモ機能全般

## スクリーンショット（任意）
[![Image from Gyazo](https://i.gyazo.com/f1a10fda6988c081c00891eb6b6bf80e.jpg)](https://gyazo.com/f1a10fda6988c081c00891eb6b6bf80e)
[![Image from Gyazo](https://i.gyazo.com/f2ff297b83b0d211af8e3bc3a1a1f1d7.jpg)](https://gyazo.com/f2ff297b83b0d211af8e3bc3a1a1f1d7)

## 補足
- レスポンシブ対応の一環として実施
- メモ編集・新規作成・生成結果保存履歴・生成結果詳細は別Issueにて対応
- UI/UX改善を目的とした調整であり、ロジック変更はなし
- ツリー構造UIのため、他画面よりも調整の影響範囲を考慮しながら実装を行った