### PR TITLE
生成結果保存一覧・詳細画面のレスポンシブ対応

### DIFF
--- a/app/views/generated_texts/index.html.erb
+++ b/app/views/generated_texts/index.html.erb
@@ -1,15 +1,15 @@
 <div class="mx-auto max-w-3xl px-4 py-8">
-  <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-    <h2 class="mb-6 text-2xl font-bold text-gray-800">
+  <div class="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6">
+    <h2 class="mb-6 text-xl font-bold text-gray-800 sm:text-2xl">
       <%= @memo.present? ? "生成結果保存履歴" : "生成結果保存履歴（全履歴）" %>
     </h2>
     <% if @generated_texts.any? %>
       <ul class="space-y-4">
         <% @generated_texts.each do |gt| %>
           <li class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
-            <div class="flex items-start justify-between gap-4">
+            <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
               <div class="min-w-0 flex-1">
-                <div class="flex gap-3">
+                <div class="flex flex-col gap-1 sm:flex-row sm:gap-3">
                   <p class="text-sm font-semibold text-blue-600">
                     <%= case gt.kind
                         when "organize" then "AI整理"
@@ -31,7 +31,7 @@
               <div class="flex flex-col items-end gap-2">
                 <p class="text-sm text-gray-400"><%= l gt.created_at, format: :short %></p>
                 <%= link_to "詳細", memo_generated_text_path(gt.memo, gt), 
-                    class: "rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-blue-700" %>
+                    class: "block w-full rounded-lg bg-blue-600 px-3 py-1.5 text-center text-sm font-semibold text-white hover:bg-blue-700" %>
               </div>
             </div>
           </li>
@@ -42,13 +42,13 @@
     <% end %>
 
 
-    <div class="mt-8 flex gap-3 border-t border-gray-200 pt-4">
+    <div class="mt-8 flex flex-col gap-3 border-t border-gray-200 pt-4 sm:flex-row">
       <% if @memo.present? %>
         <%= link_to "メモ詳細へ戻る", memo_path(@memo), 
-            class: "rounded-lg bg-gray-200 px-4 py-2 text-gray-800 font-semibold hover:bg-gray-300" %>
+            class: "block w-full rounded-lg bg-gray-200 px-4 py-2 text-center font-semibold text-gray-800 hover:bg-gray-300 sm:w-auto" %>
       <% end %>
         <%= link_to "メモ一覧へ戻る", memos_path, 
-            class: "rounded-lg bg-gray-200 px-4 py-2 text-gray-800 font-semibold hover:bg-gray-300" %>
+            class: "block w-full rounded-lg bg-gray-200 px-4 py-2 text-center font-semibold text-gray-800 hover:bg-gray-300 sm:w-auto" %>
     </div>
   </div>
 </div>

--- a/app/views/generated_texts/show.html.erb
+++ b/app/views/generated_texts/show.html.erb
@@ -28,7 +28,7 @@
 
     <div class="mt-6 flex gap-3">
       <%= link_to "生成結果保存履歴へ戻る", memo_generated_texts_path(@generated_text.memo),
-        class: "rounded-lg bg-gray-200 px-4 py-2 text-gray-800 font-semibold hover:bg-gray-300" %>
+        class: "block w-full rounded-lg bg-gray-200 px-4 py-2 text-center text-gray-800 font-semibold hover:bg-gray-300 sm:w-auto" %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 概要
生成結果保存一覧・詳細画面のレスポンシブ対応を行い、スマートフォン表示時のレイアウトおよび操作性を改善しました。

## 背景
生成結果保存一覧・詳細画面において、スマートフォン表示時にテキストや操作ボタンが横幅内に収まりづらく、レイアウトが崩れる可能性があったためレスポンシブ対応を実施しました。
（ Issue #111 ）

## 変更内容
- 一覧画面のカード内レイアウトをスマホでは縦並びに変更（flex-col sm:flex-row）
- 種別・対象メモ・本文の配置をスマホ向けに調整
- 長文テキストに折り返し対応を適用（wrap-break-word）
- 「詳細」ボタンをスマホでは全幅表示に変更（w-full sm:w-auto）
- 戻るボタンをスマホでは縦並び・全幅表示に変更
- 余白・文字サイズをデバイスごとに調整
- 生成結果詳細画面の戻るボタンの配置・サイズを調整

## 確認方法
- スマートフォン表示で生成結果保存一覧・詳細画面を確認し、以下を確認
  - 横スクロールが発生していないこと
  - テキストが自然に折り返されていること
  - 「詳細」ボタンが押しやすいサイズ・位置になっていること
  - 戻るボタンが操作しやすい配置であること
- PC表示で既存レイアウトが崩れていないことを確認
- 一覧→詳細→戻るの遷移が正常に動作することを確認
- 以下コマンドが通ることを確認
```
bundle exec rspec
bundle exec rubocop
```

## 影響範囲
### 影響がある画面
- 生成結果保存一覧画面
-  生成結果詳細画面

### 影響がないこと
- メモ一覧画面
- メモ詳細画面
- AI処理画面
- 認証画面
- AI処理ロジック・メモ機能

## スクリーンショット
生成結果保存履歴
[![Image from Gyazo](https://i.gyazo.com/3461401a2dee96644e4f945e5e53e8b3.jpg)](https://gyazo.com/3461401a2dee96644e4f945e5e53e8b3)
[![Image from Gyazo](https://i.gyazo.com/193a2c735dab7f6a6e3937340978e8f6.jpg)](https://gyazo.com/193a2c735dab7f6a6e3937340978e8f6)

生成結果詳細
[![Image from Gyazo](https://i.gyazo.com/9ea0938d64b1a739436b3bb74a94135d.jpg)](https://gyazo.com/9ea0938d64b1a739436b3bb74a94135d)

## 補足
- レスポンシブ対応の最終工程として実施
- UI/UX改善を目的とした調整であり、ロジック変更はなし
- 一覧系UIの視認性と操作性向上を意識して実装