### PR TITLE
利用規約とプライバシーポリシー

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PagesController < ApplicationController
+  # skip_before_action :authenticate_user!, only: %i[terms privacy]
+
+  def terms; end
+
+  def privacy; end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -64,5 +64,12 @@
       <% end %>
       <%= yield %>
     </main>
+
+    <footer class="fixed bottom-0 z-50 w-full border-t border-gray-200 bg-white py-4 text-center text-sm text-gray-500">
+      <div class="flex flex-col items-center justify-center gap-2 sm:flex-row sm:gap-6">
+        <%= link_to "利用規約", terms_path, class: "inline-block text-sm text-gray-600 hover:text-gray-800" %>
+        <%= link_to "プライバシーポリシー", privacy_path, class: "inline-block text-sm text-gray-600 hover:text-gray-800" %>
+      </div>
+    </footer>
   </body>
 </html>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,0 +1,84 @@
+<div class="mx-auto max-w-3xl px-4 py-8 pb-28">
+  <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+    <h2 class="mb-6 text-2xl font-bold text-gray-800">プライバシーポリシー</h2>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      本サービス「MindOutline」（以下、「本サービス」といいます。）は、利用者の個人情報の保護を重要なものと考え、以下のとおりプライバシーポリシーを定めます。
+    </p>
+
+    <hr class="my-6 border-gray-200">
+
+    <h3 class="mb-3 text-lg font-bold text-gray-800">第1条（個人情報の取得）</h3>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      本サービスは、利用登録時にメールアドレス等の個人情報を取得する場合があります。
+    </p>
+
+    <hr class="my-6 border-gray-200">
+
+    <h3 class="mb-3 text-lg font-bold text-gray-800">第2条（個人情報の利用目的）</h3>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      取得した個人情報は、以下の目的で利用します。
+    </p>
+
+    <ul class="ml-5 list-disc space-y-2 leading-7 text-gray-700">
+      <li>本サービスの提供・運営</li>
+      <li>利用者からのお問い合わせへの対応</li>
+      <li>不正利用の防止</li>
+    </ul>
+
+    <hr class="my-6 border-gray-200">
+
+    <h3 class="mb-3 text-lg font-bold text-gray-800">第3条（個人情報の第三者提供）</h3>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      本サービスは、以下の場合を除き、個人情報を第三者に提供することはありません。
+    </p>
+
+    <ul class="ml-5 list-disc space-y-2 leading-7 text-gray-700">
+      <li>法令に基づく場合</li>
+      <li>人の生命、身体または財産の保護に必要な場合</li>
+    </ul>
+
+    <hr class="my-6 border-gray-200">
+
+    <h3 class="mb-3 text-lg font-bold text-gray-800">第4条（アクセス解析ツールについて）</h3>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      本サービスでは、サービス改善のためにアクセス解析ツールを使用する場合があります。
+    </p>
+
+    <hr class="my-6 border-gray-200">
+
+    <h3 class="mb-3 text-lg font-bold text-gray-800">第5条（個人情報の管理）</h3>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      運営者は、個人情報の漏洩、紛失、改ざん等を防止するために適切な管理を行います。
+    </p>
+
+    <hr class="my-6 border-gray-200">
+
+    <h3 class="mb-3 text-lg font-bold text-gray-800">第6条（免責事項）</h3>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      本サービスからリンクされた外部サイトにおける個人情報の取り扱いについて、運営者は責任を負いません。
+    </p>
+
+    <hr class="my-6 border-gray-200">
+
+    <h3 class="mb-3 text-lg font-bold text-gray-800">第7条（プライバシーポリシーの変更）</h3>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      本ポリシーは、予告なく変更されることがあります。
+    </p>
+
+    <hr class="my-6 border-gray-200">
+
+    <h3 class="mb-3 text-lg font-bold text-gray-800">第8条（お問い合わせ）</h3>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      本ポリシーに関するお問い合わせは、本サービス内のお問い合わせフォームよりご連絡ください。
+    </p>
+  </div>
+</div>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,0 +1,88 @@
+<div class="mx-auto max-w-3xl px-4 py-8 pb-28">
+  <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+    <h2 class="mb-6 text-2xl font-bold text-gray-800">利用規約</h2>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      この利用規約（以下、「本規約」といいます。）は、本サービス「MindOutline」（以下、「本サービス」といいます。）の利用条件を定めるものです。利用者の皆さまには、本規約に従って本サービスをご利用いただきます。
+    </p>
+
+    <hr class="my-6 border-gray-200">
+
+    <h3 class="mb-3 text-lg font-bold text-gray-800">第1条（適用）</h3>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      本規約は、利用者と本サービス提供者との間の本サービスの利用に関わる一切の関係に適用されるものとします。
+    </p>
+
+    <hr class="my-6 border-gray-200">
+
+    <h3 class="mb-3 text-lg font-bold text-gray-800">第2条（利用登録）</h3>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      本サービスにおいては、利用者が本規約に同意の上、所定の方法により利用登録を行うことで、利用登録が完了するものとします。
+    </p>
+
+    <hr class="my-6 border-gray-200">
+
+    <h3 class="mb-3 text-lg font-bold text-gray-800">第3条（禁止事項）</h3>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      利用者は、本サービスの利用にあたり、以下の行為をしてはなりません。
+    </p>
+
+    <ul class="ml-5 list-disc space-y-2 leading-7 text-gray-700">
+      <li>法令または公序良俗に違反する行為</li>
+      <li>犯罪行為に関連する行為</li>
+      <li>本サービスの運営を妨害する行為</li>
+      <li>他の利用者に不利益、損害、不快感を与える行為</li>
+      <li>不正アクセスを試みる行為</li>
+      <li>その他、運営者が不適切と判断する行為</li>
+    </ul>
+
+    <hr class="my-6 border-gray-200">
+
+    <h3 class="mb-3 text-lg font-bold text-gray-800">第4条（本サービスの提供の停止等）</h3>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      運営者は、以下のいずれかの事由があると判断した場合、利用者に事前に通知することなく本サービスの全部または一部の提供を停止または中断することができるものとします。
+    </p>
+
+    <ul class="ml-5 list-disc space-y-2 leading-7 text-gray-700">
+      <li>システムの保守点検または更新を行う場合</li>
+      <li>天災などの不可抗力によりサービス提供が困難となった場合</li>
+      <li>その他、運営者がサービス提供が困難と判断した場合</li>
+    </ul>
+
+    <hr class="my-6 border-gray-200">
+
+    <h3 class="mb-3 text-lg font-bold text-gray-800">第5条（免責事項）</h3>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      本サービスに関して利用者に生じた損害について、運営者は一切の責任を負いません。
+    </p>
+
+    <hr class="my-6 border-gray-200">
+
+    <h3 class="mb-3 text-lg font-bold text-gray-800">第6条（サービス内容の変更等）</h3>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      運営者は、利用者への事前の告知なく、本サービスの内容を変更、追加または廃止することができるものとします。
+    </p>
+
+    <hr class="my-6 border-gray-200">
+
+    <h3 class="mb-3 text-lg font-bold text-gray-800">第7条（利用規約の変更）</h3>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      運営者は、必要と判断した場合には、利用者に通知することなく本規約を変更することができるものとします。
+    </p>
+
+    <hr class="my-6 border-gray-200">
+
+    <h3 class="mb-3 text-lg font-bold text-gray-800">第8条（準拠法・裁判管轄）</h3>
+
+    <p class="mb-6 leading-7 text-gray-700">
+      本規約の解釈にあたっては、日本法を準拠法とします。
+    </p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,6 @@ Rails.application.routes.draw do
   end
 
   get '/up', to: proc { [200, { 'Content-Type' => 'text/plain' }, ['OK']] }
+  get "/terms", to: "pages#terms"
+  get "/privacy", to: "pages#privacy"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,6 @@ Rails.application.routes.draw do
   end
 
   get '/up', to: proc { [200, { 'Content-Type' => 'text/plain' }, ['OK']] }
-  get "/terms", to: "pages#terms"
-  get "/privacy", to: "pages#privacy"
+  get '/terms', to: 'pages#terms'
+  get '/privacy', to: 'pages#privacy'
 end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Pages', type: :request do
+  describe 'GET /terms' do
+    it 'returns http success and displays terms page' do
+      get terms_path
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include('利用規約')
+    end
+  end
+
+  describe 'GET /privacy' do
+    it 'returns http success and displays privacy page' do
+      get privacy_path
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include('プライバシーポリシー')
+    end
+  end
+end


### PR DESCRIPTION
## 概要
利用規約およびプライバシーポリシーのページを実装し、未ログイン状態でも閲覧可能にしました。

## 背景
本サービスはポートフォリオとして公開しているが、利用規約・プライバシーポリシーが未整備であり、サービスとしての信頼性向上のために実装が必要であった。
（ Issue #114 ）

## 変更内容
- `PagesController` を作成し、以下のページを実装
  - `/terms`（利用規約）
  - `/privacy`（プライバシーポリシー）
- ルーティングを追加
  - `terms_path`
  - `privacy_path`
- 未ログイン状態でも閲覧可能に設定
- フッターにリンクを追加
  - 利用規約
  - プライバシーポリシー
- 各ページに利用規約・プライバシーポリシーの内容を記載
- ページ全体のレイアウトを調整（カードレイアウト・余白・レスポンシブ対応）

## 確認方法
- 未ログイン状態で以下URLにアクセスできることを確認
  - `/terms`
  - `/privacy`
- フッターから各ページに遷移できることを確認
- PC・スマートフォン表示でレイアウトが崩れていないことを確認
- 以下コマンドが通ることを確認
```
bundle exec rspec
bundle exec rubocop
```

## 影響範囲
### 影響がある画面
- フッター（全ページ）
- 利用規約ページ
- プライバシーポリシーページ

### 影響がないこと
- メモ機能
- AI処理機能
- 認証機能

## スクリーンショット

利用規約
[![Image from Gyazo](https://i.gyazo.com/c02d0d15326f4a1a786d84ff4a6d48b8.png)](https://gyazo.com/c02d0d15326f4a1a786d84ff4a6d48b8)

プライバシーポリシー
[![Image from Gyazo](https://i.gyazo.com/fae01372221c65ddfa92fecd4b573692.png)](https://gyazo.com/fae01372221c65ddfa92fecd4b573692)

## 補足
- 静的ページの追加によるサービス信頼性向上を目的とした対応
- ロジック変更は伴わない
- request spec にてルーティングおよび表示確認を実施