### PR TITLE
ローディングアニメーションの実装

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -5,7 +5,8 @@
 import { application } from "./application"
 import HelloController from "./hello_controller"
 import TreeToggleController from "./tree_toggle_controller"
+import LoadingController from "./loading_controller"
 
 application.register("hello", HelloController)
 application.register("tree-toggle", TreeToggleController)
-
+application.register("loading", LoadingController)

--- a/app/javascript/controllers/loading_controller.js
+++ b/app/javascript/controllers/loading_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["button", "message"]
+
+  //フォーム送信時に呼び出す
+  show(){
+    this.buttonTarget.disabled = true;
+    this.buttonTarget.value = "生成中...";
+    this.buttonTarget.classList.add("opacity-70", "cursor-not-allowed");
+
+    this.messageTarget.classList.remove("hidden");
+    this.messageTarget.classList.add("flex");
+  }
+}

--- a/app/views/memos/ai_tools.html.erb
+++ b/app/views/memos/ai_tools.html.erb
@@ -51,7 +51,17 @@
       </div>
     </div>
 
-    <%= form_with(url: ai_generate_memo_path(@memo), method: :post, data: { turbo: false }, local: true, class: "mb-6") do |f| %>
+    <%= form_with(
+        url: ai_generate_memo_path(@memo),
+        method: :post,
+        data: { 
+          turbo: false,
+          controller: "loading",
+          action: "submit->loading#show"
+        },
+        local: true,
+        class: "mb-6"
+      ) do |f| %>
       <%= hidden_field_tag :tab, @tab %>
 
       <% if @tab == "organize" %>
@@ -85,7 +95,13 @@
       <% end %>
 
       <%= f.submit "生成する",
+        data: { loading_target: "button" },
         class: "w-full rounded-lg bg-green-600 px-4 py-2 font-semibold text-white hover:bg-green-700 sm:w-auto" %>
+      
+      <div data-loading-target="message" class="mt-3 hidden text-sm text-gray-500 gap-1">
+        <span class="inline-block h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-green-600"></span>
+        <span>生成中です。少しお待ちください...</span>
+      </div>
     <% end %>
 
     <div id="ai_result">

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,8 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 
 RSpec.configure do |config|
+  config.include Devise::Test::IntegrationHelpers, type: :request
+
   config.use_transactional_fixtures = true
   config.filter_rails_from_backtrace!
 end

--- a/spec/requests/memos_ai_tools_spec.rb
+++ b/spec/requests/memos_ai_tools_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'MemosAiTools', type: :request do
+  describe 'GET /memos/:id/ai_tools' do
+    it 'displays AI tools page' do
+      user = User.create!(
+        name: 'テストユーザー',
+        email: 'test@example.com',
+        password: 'password',
+        password_confirmation: 'password'
+      )
+
+      memo = Memo.create!(
+        user: user,
+        title: 'テストメモ',
+        content: 'テスト内容'
+      )
+
+      sign_in user
+
+      get ai_tools_memo_path(memo)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include('AI処理')
+      expect(response.body).to include('生成する')
+    end
+  end
+end


### PR DESCRIPTION
## 概要
AI生成中のローディング表示を追加し、生成処理中であることがユーザーに分かるようにしました。

## 背景

AI生成処理には待ち時間が発生するため、従来はボタン押下後に処理が始まっているか分かりづらい状態でした。
ユーザーが二重送信したり、不安に感じたりすることを防ぐため、ローディング表示を追加しました。
（ Issue #116 ）

## 変更内容
- AI生成フォーム送信時にローディング表示を追加
- 生成中は送信ボタンを無効化し、文言を「生成中...」に変更
- 生成中メッセージと円形スピナーを表示
- Stimulus controller を追加し、送信時の表示切り替えを実装
- AI処理画面のrequest specを追加
- request specでDeviseの sign_in を使用できるよう設定を追加

## 確認方法
- AI処理画面で「生成する」ボタンを押下
- 以下を確認
  - ボタンが「生成中...」に変わること
  - ボタンが無効化され、二重送信できないこと
  - 生成中メッセージとスピナーが表示されること
  - AI生成完了後、生成結果が正常に表示されること
- PC・スマートフォン表示でローディング表示が崩れていないこと
- 以下コマンドが通ることを確認
```
bundle exec rspec
bundle exec rubocop
```

## 影響範囲
### 影響がある画面
- AI処理画面

### 影響がないこと
- AI整理・AI要約・文章生成の処理ロジック
- メモ一覧・メモ詳細画面
- 生成結果保存機能
- 認証機能

## スクリーンショット

## 補足
- AI処理中のユーザー体験改善を目的とした対応
- 削除などの危険操作ではないため、確認ダイアログの制御は深追いせず、ローディング表示と二重送信防止を優先
- スマートフォン開発環境で表示されるHTTP通信警告は本番HTTPS環境では発生しない想定
- request spec により、AI処理画面が正常に表示されることを確認しています