### PR TITLE
フッターと下部ボタンの重なりを解消

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
       </div>
     </header>
 
-    <main class="pt-20">
+    <main class="pt-20 pb-28">
       <% flash.each do |type, message| %>
         <% css_class =
           case type.to_sym

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
       </div>
     </header>
 
-    <main class="pt-20 pb-28">
+    <main class="pt-20 pb-28 bg-gray-50">
       <% flash.each do |type, message| %>
         <% css_class =
           case type.to_sym


### PR DESCRIPTION
## 概要
fixedフッターが下部コンテンツに重ならないよう、ページ全体に下余白を追加しました。

## 背景
スマートフォン表示時に、AI処理画面などの下部ボタンが固定フッターに隠れてしまい、操作できない問題が発生していたため対応しました。

## 変更内容
- `application.html.erb` のメインコンテンツ領域に `pb-28` を追加
- fixedフッターと下部ボタン・リンクが重ならないように調整
- `main` に `bg-gray-50` を追加し、下余白部分の背景色が他の画面背景と自然につながるように修正
- PC表示でも下部に自然な余白ができるように修正

## 確認方法
- スマートフォン表示でAI処理画面を確認
- 「メモ一覧へ戻る」「メモ詳細に戻る」ボタンがフッターに隠れないこと
- 下部ボタンがタップ可能であること
- PC表示で余白が不自然でないことを確認
- Chrome DevToolsおよび実機で表示を確認
- 以下コマンドが通ることを確認
```
bundle exec rspec
bundle exec rubocop
```

## 影響範囲
### 影響がある画面
- 全ページ共通のメインコンテンツ領域
- fixedフッター付近に下部ボタン・リンクがある画面

### 影響がないこと
- 各機能の処理ロジック
- AI生成処理
- 認証処理
- メモ・生成結果の保存処理

## スクリーンショット

[![Image from Gyazo](https://i.gyazo.com/9e3bc83d0587df4959d2bd2cd3cf515a.jpg)](https://gyazo.com/9e3bc83d0587df4959d2bd2cd3cf515a)

## 補足
- fixedフッターを使用しているため、共通レイアウト側で下余白を確保する対応とした
- `pb-28` 追加により余白部分の背景が白く見えたため、`main` に `bg-gray-50` を追加して画面全体の背景色を統一した
- 個別画面ごとの調整ではなく、全体に適用することで同様の重なりを防止する方針
- UI調整のみであり、ロジック変更はなし