### PR TITLE
SMTP接続エラーの修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,12 +102,14 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
 
   config.action_mailer.smtp_settings = {
-    address: ENV.fetch('SMTP_ADDRESS'),
-    port: ENV.fetch('SMTP_PORT', 587),
-    domain: ENV.fetch('SMTP_DOMAIN'),
+    address: ENV.fetch('SMTP_ADDRESS', 'smtp.gmail.com'),
+    port: ENV.fetch('SMTP_PORT', 587).to_i,
+    domain: ENV.fetch('SMTP_DOMAIN', 'gmail.com'),
     user_name: ENV.fetch('SMTP_USER_NAME'),
     password: ENV.fetch('SMTP_PASSWORD'),
     authentication: :plain,
-    enable_starttls_auto: true
+    enable_starttls_auto: true,
+    open_timeout: 10,
+    read_timeout: 10
   }
 end


### PR DESCRIPTION
## 概要
本番環境でパスワードリセットメール送信時に発生していたSMTP接続エラーを修正しました。

## 背景
本番環境でパスワード再設定メールを送信した際、SMTPサーバーへの接続がタイムアウトし、エラー画面が表示されていました。
ログを確認したところ、Net::OpenTimeout が発生しており、SMTP接続設定の見直しが必要でした。
（Issue #120 ）

## 変更内容
- 本番環境のSMTP設定を修正
- SMTP_PORT を整数として扱うように調整
- Gmail SMTP接続に必要な設定を整理
- SMTP接続時のタイムアウト設定を追加・調整
- 本番環境でメール送信処理が正常に進むよう修正

## 確認方法
- Render本番環境でパスワード再設定画面を開く
- 登録済みメールアドレスを入力して送信
- エラー画面が表示されないことを確認
- パスワード再設定メールが届くことを確認
- メール内リンクが https://mindoutline.app のURLになっていることを確認
- メール内リンクからパスワード再設定画面へ遷移できることを確認
- 新しいパスワードでログインできることを確認
- 以下コマンドが通ることを確認
```
bundle exec bin/rails test
bundle exec rspec
bundle exec rubocop
```

## 影響範囲
### 影響がある機能
- 本番環境でのパスワードリセットメール送信
- ActionMailerのSMTP設定

### 影響がないこと
- 開発環境での letter_opener_web によるメール確認
- テスト環境のメール送信確認
- 通常ログイン・新規登録処理
- メモ機能
- AI処理機能

## スクリーンショット
本番環境でパスワード再設定メールが届いた状態を添付予定

## 補足
- Renderのログで Net::OpenTimeout が発生していたため、SMTP接続設定を見直しました
- Gmail SMTPを利用するため、Render側の環境変数設定も併せて確認しています
- 本番環境でのメール送信確認をもって対応完了とします