### PR TITLE
Resendによるパスワードリセットメール送信

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,3 +85,5 @@ gem 'openai', '~> 0.56.0'
 
 gem 'devise-i18n'
 gem 'rails-i18n'
+
+gem 'resend'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
+    csv (3.3.5)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -124,6 +125,10 @@ GEM
     erubi (1.13.1)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    httparty (0.24.2)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -171,6 +176,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.27.0)
     msgpack (1.8.0)
+    multi_xml (0.9.1)
+      bigdecimal (>= 3.1, < 5)
     net-imap (0.6.3)
       date
       net-protocol
@@ -273,6 +280,9 @@ GEM
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
+    resend (1.3.0)
+      base64
+      httparty (>= 0.22.0)
     responders (3.2.0)
       actionpack (>= 7.0)
       railties (>= 7.0)
@@ -400,6 +410,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (= 7.2.2)
   rails-i18n
+  resend
   rspec-rails (~> 7.0)
   rubocop (~> 1.85, >= 1.85.1)
   rubocop-rails-omakase
@@ -440,6 +451,7 @@ CHECKSUMS
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   cssbundling-rails (1.4.3) sha256=53aecd5a7d24ac9c8fcd92975acd0e830fead4ee4583d3d3d49bb64651946e41
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   devise (5.0.3) sha256=c4c065051cdc4ace11547b2b7f5c3c4c97d0f1269250f5fe90f614ff78f29546
@@ -449,6 +461,7 @@ CHECKSUMS
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
+  httparty (0.24.2) sha256=8fca6a54aa0c4aa4303a0fd33e5e2156175d6a5334f714263b458abd7fda9c38
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
@@ -470,6 +483,7 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
+  multi_xml (0.9.1) sha256=7ce766b59c17241ed62976caeae1fae9b2431b263398c35396239a68c4a64e57
   net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
@@ -515,6 +529,7 @@ CHECKSUMS
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  resend (1.3.0) sha256=e9e141b0a14cd060e2dac70c552a2f6e688d601f7af5bb47f874b473949d0d1d
   responders (3.2.0) sha256=89c2d6ac0ae16f6458a11524cae4a8efdceba1a3baea164d28ee9046bd3df55a
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,23 +93,10 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  config.action_mailer.delivery_method = :resend
+  config.action_mailer.perform_deliveries = true
   config.action_mailer.default_url_options = {
     host: 'mindoutline.app',
     protocol: 'https'
-  }
-
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.perform_deliveries = true
-
-  config.action_mailer.smtp_settings = {
-    address: ENV.fetch('SMTP_ADDRESS', 'smtp.gmail.com'),
-    port: ENV.fetch('SMTP_PORT', 587).to_i,
-    domain: ENV.fetch('SMTP_DOMAIN', 'gmail.com'),
-    user_name: ENV.fetch('SMTP_USER_NAME'),
-    password: ENV.fetch('SMTP_PASSWORD'),
-    authentication: :plain,
-    enable_starttls_auto: true,
-    open_timeout: 10,
-    read_timeout: 10
   }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -89,7 +89,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.

--- a/config/initializers/resend.rb
+++ b/config/initializers/resend.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'resend'
+
+Resend.api_key = if Rails.env.production?
+                   ENV.fetch('RESEND_API_KEY')
+                 else
+                   ENV.fetch('RESEND_API_KEY', nil)
+                 end


### PR DESCRIPTION
## 概要
Resend導入後、開発環境・テスト環境で RESEND_API_KEY が未設定の場合にアプリ起動やRSpecが失敗しないよう、Resendの初期化設定を修正しました。

## 背景
RenderとGmailの仕様上、メール送信時にタイムアウトが発生するため、本番環境でのパスワードリセットメール送信をResend API経由に切り替える対応を行いました。
切り替え対応中、config/initializers/resend.rb で RESEND_API_KEY を必須としていたため、テスト環境でRails起動時に KeyError が発生していました。
本番環境ではAPIキー未設定時に検知できる状態を保ちつつ、開発環境・テスト環境ではAPIキー未設定でも起動できるようにする必要がありました。

## 変更内容
- config/initializers/resend.rb の環境変数参照方法を修正
- 本番環境では RESEND_API_KEY を必須にする
- 開発環境・テスト環境では RESEND_API_KEY が未設定でも起動できるようにする
- RSpec実行時にResendの環境変数がなくてもテストが通るように調整

## 確認方法
- 以下コマンドが通ることを確認
```
bundle exec rspec
bundle exec rubocop
```
- 開発環境でRailsが正常に起動することを確認
- テスト環境で RESEND_API_KEY 未設定でもRSpecが実行できることを確認

## 影響範囲
### 影響がある箇所
- Resendの初期化処理
- ActionMailerの本番メール送信設定

### 影響がないこと
- 開発環境の letter_opener_web によるメール確認
- テスト環境の ActionMailer::Base.deliveries を使ったメール送信テスト
- 通常ログイン・新規登録処理
- メモ機能
- AI処理機能

## 補足
- 本番環境ではRender側に RESEND_API_KEY を設定する前提です
- 開発環境・テスト環境ではResend APIキーを使用しないため、未設定でも起動できるようにしています
- Render無料枠ではSMTPポートが制限されるため、本番メール送信はSMTPではなくResend APIを利用する方針です